### PR TITLE
Updated tool.rkt

### DIFF
--- a/tool.rkt
+++ b/tool.rkt
@@ -16,10 +16,10 @@
         (inherit register-toolbar-button
                  get-button-panel
                  get-definitions-text
-;                 ensure-rep-shown
-                 get-interactions-text)
+                 get-interactions-text
+                 ensure-rep-shown)
         (define run-chez (new switchable-button%
-                              [label "Run Chez"]
+                              [label "Run"]
                               [parent (get-button-panel)]
                               [bitmap icon]
                               [callback (λ (self)
@@ -34,7 +34,7 @@
                                           (match-define (list stdout stdin pid stderr _)
                                             (process (format "scheme --script ~a" tmpfile)))
                                           (send (get-interactions-text) reset-console)
-;                                          (ensure-rep-shown #f)
+                                          (ensure-rep-shown (get-interactions-text))
                                           (send (get-interactions-text)
                                                 insert
                                                 (format "~a~a\n" (port->string stdout)

--- a/tool.rkt
+++ b/tool.rkt
@@ -16,8 +16,8 @@
         (inherit register-toolbar-button
                  get-button-panel
                  get-definitions-text
-                 get-interactions-text
-                 ensure-rep-shown)
+;                 ensure-rep-shown
+                 get-interactions-text)
         (define run-chez (new switchable-button%
                               [label "Run Chez"]
                               [parent (get-button-panel)]
@@ -34,7 +34,7 @@
                                           (match-define (list stdout stdin pid stderr _)
                                             (process (format "scheme --script ~a" tmpfile)))
                                           (send (get-interactions-text) reset-console)
-                                          (ensure-rep-shown #f)
+;                                          (ensure-rep-shown #f)
                                           (send (get-interactions-text)
                                                 insert
                                                 (format "~a~a\n" (port->string stdout)


### PR DESCRIPTION
DrRacket updated the implementation of "ensure-rep-shown" and providing "#f" as an argument throws an error. See the below implementation from DrRacket documentation. 

method (send a-drracket:unit:frame ensure-rep-shown rep) → void? 
rep : (is-a?/c drracket:rep:text<%>)

I went back to a previous version of DrRacket where this repository worked, and providing "get-interactions-text" instead has the same functionality. 